### PR TITLE
feat: drop warning (#1455)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,10 @@ env:
   es6: true
 rules:
   global-require: off
-  no-unused-vars: [2, {
+  no-console: ['error', {
+    allow: ['warn', 'error', 'info']
+  }]
+  no-unused-vars: ['error', {
     vars: all,
     args: after-used,
     varsIgnorePattern: ^_,

--- a/package.json
+++ b/package.json
@@ -137,8 +137,7 @@
     "memoize-one": "^4.0.3",
     "prop-types": "^15.6.2",
     "react-overlays": "^2.0.0-0",
-    "uncontrollable": "^7.0.0",
-    "warning": "^4.0.2"
+    "uncontrollable": "^7.0.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -9,7 +9,6 @@ import {
   DayLayoutAlgorithmPropType,
   views as componentViews,
 } from './utils/propTypes'
-import warning from 'warning'
 
 import { notify } from './utils/helpers'
 import { navigate, views } from './utils/constants'
@@ -942,7 +941,9 @@ class Calendar extends React.Component {
       if (viewComponent.range) {
         onRangeChange(viewComponent.range(date, { localizer }), view)
       } else {
-        warning(true, 'onRangeChange prop not supported for this view')
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('onRangeChange prop not supported for this view')
+        }
       }
     }
   }

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -1,7 +1,6 @@
 import * as dates from '../utils/dates'
 import oldGlobalize from './oldGlobalize'
 import { DateLocalizer } from '../localizer'
-import warning from 'warning'
 
 let dateRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, { date: 'short' }, culture) +
@@ -62,11 +61,12 @@ export default function(globalize) {
       const firstDay = weekData.firstDay[territory || '001']
       return days.indexOf(firstDay)
     } catch (e) {
-      warning(
-        true,
-        `Failed to accurately determine first day of the week.
-            Is supplemental data loaded into CLDR?`
-      )
+      if (process.env.NODE_ENV !== 'production') {
+        console.error(
+          'Failed to accurately determine first day of the week.' +
+            ' Is supplemental data loaded into CLDR?'
+        )
+      }
       // maybe cldr supplemental is not loaded? revert to original method
       const date = new Date()
       //cldr-data doesn't seem to be zero based


### PR DESCRIPTION
Maintainers of `warning` refuses evaluation saying it's a 1:1 fork of
fbjs version. I tend to replace it with just console statements warpped
in NODE_ENV check. Looks much simpler to me, does not require
additional tools like babel plugin and does not require commonjs module.