### PR TITLE
fix: prevent endless loop when adding event the DST begin day (#1635)

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -349,7 +349,7 @@ class DayColumn extends React.Component {
 
     while (dates.lte(current, endDate)) {
       slots.push(current)
-      current = dates.add(current, this.props.step, 'minutes')
+      current = new Date(+current + this.props.step * 60 * 1000) // using Date ensures not to create an endless loop the day DST begins
     }
 
     notify(this.props.onSelectSlot, {


### PR DESCRIPTION
* Prevent endless loop when adding event the DST begin day

* Add a comment for the reason of the change